### PR TITLE
Cache observables

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,20 +2,24 @@ import {Observable} from "rxjs/Observable";
 import {takeUntil} from "rxjs/operators";
 import {ReplaySubject} from "rxjs/ReplaySubject";
 
-export function componentDestroyed(component: any): Observable<true> {
+export type OnDestroyLike = {
+    ngOnDestroy(): void;
+}
+
+export function componentDestroyed(component: OnDestroyLike): Observable<true> {
     if (component.__componentDestroyed$) {
         return component.__componentDestroyed$;
     }
     const oldNgOnDestroy = component.ngOnDestroy;
     const stop$ = new ReplaySubject<true>();
     component.ngOnDestroy = function () {
-        oldNgOnDestroy && oldNgOnDestroy.apply(component, arguments);
+        oldNgOnDestroy && oldNgOnDestroy.apply(component);
         stop$.next(true);
         stop$.complete();
     };
     return component.__componentDestroyed$ = stop$.asObservable();
 }
 
-export function untilComponentDestroyed<T>(component: any): (source: Observable<T>) => Observable<T> {
+export function untilComponentDestroyed<T>(component: OnDestroyLike): (source: Observable<T>) => Observable<T> {
     return (source: Observable<T>) => source.pipe(takeUntil(componentDestroyed(component)));
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,9 @@ import {Observable} from "rxjs/Observable";
 import {takeUntil} from "rxjs/operators";
 import {ReplaySubject} from "rxjs/ReplaySubject";
 
-export type OnDestroyLike = {
+export interface OnDestroyLike {
     ngOnDestroy(): void;
+    [key: string]: any;
 }
 
 export function componentDestroyed(component: OnDestroyLike): Observable<true> {


### PR DESCRIPTION
This pull request improves 3 things:
* Allows for components that don't already implement ngOnDestroy()
* Caches the Observable on the component, to avoid creating a new one and newly wrapping ngOnDestroy with every call
* Uses ReplaySubject in order to be sure that any attempts to subscribe after ngOnDestroy() are blocked